### PR TITLE
Eliminar doble registro de nuevos elementos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
     firebase,
     glue,
     golem (>= 0.3.2),
+    htmltools,
     ids,
     lubridate,
     purrr,

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -41,7 +41,7 @@ app_server <- function(input, output, session) {
         glue::glue("sesion iniciada de {user}", user = rv$user_iniciado) |>
           message()
 
-        mod_secure_ui("secure_1", privileges = rv$privileges, user_iniciado)
+        mod_secure_ui("secure_1", privileges = rv$privileges, user_iniciado = rv$user_iniciado)
       }
 
     # mod_secure_ui("secure_1", privileges = rv$privileges)

--- a/R/boxHide.R
+++ b/R/boxHide.R
@@ -1,0 +1,15 @@
+boxHide <- function(box) {
+    boxId <- boxFindId(box)
+
+    box |>
+        tagAppendAttributes(.cssSelector = glue::glue("#{boxId}"), style = "display: none;")
+}
+
+boxFindId <- function(box) {
+    boxQuery <- htmltools::tagQuery(box)
+    innerBox <- boxQuery$
+        children(".card")$
+        selectedTags()[[1]]
+
+    tagGetAttribute(innerBox, "id")
+}

--- a/R/isFalsy.R
+++ b/R/isFalsy.R
@@ -1,0 +1,8 @@
+isFalsy <- function(...) {
+    dots <- list(...)
+    vec <- logical(length(dots))
+    for (i in seq_along(dots)) {
+        vec[i] <- !isTruthy(dots[[i]])
+    }
+    any(vec)
+}

--- a/R/mod_secure.R
+++ b/R/mod_secure.R
@@ -13,14 +13,14 @@ mod_secure_ui <- function(id, privileges, user_iniciado){
     bs4Dash::dashboardPage(
         # preloader = list(html = tagList(waiter::spin_pixel(), "Cargando ..."), color = "#3c8dbc"),
       bs4Dash::dashboardHeader(
-          title = "Reporte",
-          rightUi = tagList(
-              bs4Dash::dropdownMenu(
-                  icon = icon("gear"),
-                  type = "messages",
-                  bs4Dash::notificationItem(inputId = ns("refresh"), text = icon("refresh"), status = "primary")
-              )
-          )
+          title = "Reporte"
+          # rightUi = tagList(
+          #     bs4Dash::dropdownMenu(
+          #         icon = icon("gear"),
+          #         type = "messages",
+          #         bs4Dash::notificationItem(inputId = ns("refresh"), text = icon("refresh"), status = "primary")
+          #     )
+          # )
       ),
       bs4Dash::dashboardSidebar(
         collapsed = TRUE,
@@ -71,7 +71,7 @@ mod_secure_ui <- function(id, privileges, user_iniciado){
           ),
           bs4Dash::tabItem(
             tabName = "templates",
-            mod_templates_ui(ns("templates_1"))
+            mod_templates_ui(ns("templates_1"), user_iniciado)
           ),
           bs4Dash::tabItem(
             tabName = "admin_groups",

--- a/R/mod_task_manager.R
+++ b/R/mod_task_manager.R
@@ -49,7 +49,6 @@ mod_task_man_output <- function(id, user_iniciado) {
                         label = "¿Necesita plantilla?",
                         choices = c("No" = "false",
                                     "Sí" = "true")
-                        # status = "info"
                     )
                 ),
                 col_6(
@@ -75,7 +74,7 @@ mod_task_man_output <- function(id, user_iniciado) {
                     btn_guardar(ns("save"), block = TRUE)
                 )
             )
-        )
+        ) |> boxHide()
     )
 }
 
@@ -86,7 +85,7 @@ mod_task_man_server <- function(id, user_iniciado) {
     moduleServer(id, function(input, output, session) {
         ns <- session$ns
 
-        bs4Dash::updateBox("box_nueva_tarea", "remove")
+        # bs4Dash::updateBox("box_nueva_tarea", "remove")
 
         choices_for_tasks <- user_get_choices_for_tasks(user_iniciado)
 
@@ -138,7 +137,7 @@ mod_task_man_server <- function(id, user_iniciado) {
         })
 
         observe({
-            bs4Dash::updateBox(id = "box_nueva_tarea", action = "restore")
+            bs4Dash::updateBox(id = "box_nueva_tarea", action = "restore", session = session)
         }) |> bindEvent(input$add)
 
         observeEvent(input$type,{
@@ -159,14 +158,14 @@ mod_task_man_server <- function(id, user_iniciado) {
 
                 updateTextAreaInput(session, "description", value = "")
 
-                bs4Dash::updateBox(id = "box_nueva_tarea", action = "remove")
+                bs4Dash::updateBox(id = "box_nueva_tarea", action = "remove", session = session)
 
                 alert_success(session = session, text = "La tarea se añadió correctamente")
             }
         })
 
         observe({
-            bs4Dash::updateBox(id = "box_nueva_tarea", action = "remove")
+            bs4Dash::updateBox(id = "box_nueva_tarea", action = "remove", session = session)
         }) |> bindEvent(input$cancelar)
 
         # return

--- a/R/mod_template_manager.R
+++ b/R/mod_template_manager.R
@@ -1,0 +1,210 @@
+#' template_manager UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd
+#'
+#' @importFrom shiny NS tagList
+mod_template_manager_ui <- function(id) {
+    ns <- NS(id)
+    btn_agregar(ns("add"), icon = icon("plus"))
+}
+
+mod_template_manager_output <- function(id, user_iniciado) {
+    ns <- NS(id)
+    
+    group_id <- gruser_get_groups(user_iniciado)
+    all_owners <- union(user_iniciado, group_id)
+    
+    tagList(
+        tags$hr(),
+        bs4Dash::box(
+            title = "Gestión de plantillas",
+            width = 12,
+            id = ns("box_manager"),
+            
+            fluidRow(
+              col_6(
+                  textInput(inputId = ns("temp_description"),
+                            label = "Nombre de plantilla",
+                            placeholder = "Ingresar nombre de plantilla")
+              ),
+              col_4(
+                  selectInput(
+                      inputId = ns("template_owner"),
+                      label = "Seleccione dueño de plantilla",
+                      choices = setNames(all_owners, all_owners |> purrr::map_chr(user_get_names))
+                  )
+              ),
+              col_2(
+                  selectInput(ns("plantilla_mapro"), 
+                              label = "¿Es proceso MAPRO?", 
+                              choices = c("No", "Sí"))
+              )
+            ),
+            
+            conditionalPanel(
+                condition = "input.plantilla_mapro == 'Sí'",
+                ns = ns,
+                textInput(inputId = ns("template_id"),
+                          label = "ID de proceso",
+                          placeholder = "Solo llenar en procesos MAPRO")
+            ),
+            h5("Ingresar tareas"),
+            fluidRow(
+                col_10(
+                    uiOutput(ns("step_list")),
+                ),
+                col_2(
+                    btn_add(ns("add_step"), size = "sm"),
+                    btn_minus(ns("rm_step"), size = "sm")
+                )
+                # col_1(btn_add(ns("add_step"), size = "sm")),
+                # col_1(btn_minus(ns("rm_step"), size = "sm"))
+            ),
+            btn_cancelar(ns("cancelar")), 
+            btn_guardar(ns("guardar"))
+        ) |> boxHide()
+    )
+}
+
+#' template_manager Server Functions
+#'
+#' @noRd
+mod_template_manager_server <- function(id, user_iniciado) {
+    moduleServer(id, function(input, output, session) {
+        ns <- session$ns
+        
+        step_count <- reactiveVal(1L)
+        step_list_numbers <- reactive(seq_len(step_count()))
+        
+        out <- reactiveValues(
+            save_success = 0L
+        )
+        
+        template_id <- reactive({
+            if (input$template_id == "") {
+                ids::proquint(n_words = 3, use_openssl = TRUE)
+            } else {
+                input$template_id
+            }
+        })
+        
+        new_template_data <- reactive({
+            data.frame(
+                template_id = template_id(),
+                template_description = input$temp_description,
+                user_id = input$template_owner
+            )
+        })
+        
+        new_template_steps_data <- reactive({
+            step_list_numbers() |>
+                lapply(function(x) {
+                    data.frame(
+                        user_id = input$template_owner,
+                        template_id = template_id(),
+                        step_id = sprintf("step_%02i", x),
+                        step_description = input[[sprintf("step_%02i", x)]]
+                    )
+                }) |>
+                (\(x) do.call(what = rbind, args = x))() # ugly but owrks in R 4.1
+            # do.call(what = rbind, args = _) # needs R 4.2
+        })
+        
+        observe({
+            bs4Dash::updateBox("box_manager", action = "restore", session = session)
+        }) |> bindEvent(input$add)
+        
+        observeEvent(input$add_step, step_count(step_count() + 1L))
+        
+        observeEvent(input$rm_step, if (step_count() > 1L) step_count(step_count() - 1L))
+        
+        observeEvent(input$guardar, {
+            
+            if (isFalsy(c(input$temp_description, input$step_01))) {
+                alert_error(session, "Debe indicar descripción de plantilla y actividades")
+            } else {
+                step_insert(new_template_steps_data())
+                template_insert(new_template_data())
+                
+                bs4Dash::updateBox("box_manager", action = "remove", session = session)
+                
+                updateTextInput(session = session,
+                                inputId = "temp_description",
+                                value = "")
+                
+                updateTextInput(session = session,
+                                inputId = "template_id",
+                                value = "")
+                
+                # Resetear todos los inputs de step
+                step_list_numbers() |>
+                    lapply(function(x) {
+                        updateTextInput(session = session,
+                                        inputId = sprintf("step_%02i", x),
+                                        value = "")
+                    })
+                
+                out$save_success <- out$save_success + 1L
+                
+                alert_success(session, "Plantilla añadida")
+            }
+        })
+        
+        observe({
+            bs4Dash::updateBox("box_manager", action = "remove", session = session)
+        }) |> bindEvent(input$cancelar)
+        
+        output$step_list <- renderUI({
+            step_list_numbers() |>
+                lapply(function(x) {
+                    textInput(
+                        inputId = ns(sprintf("step_%02i", x)),
+                        label = NULL,
+                        placeholder = sprintf("Ingresar tarea %02i", x),
+                        value = isolate(input[[sprintf("step_%02i", x)]])
+                    )
+                })
+        })
+        
+        # return value
+        reactive(out$save_success)
+
+    })
+}
+
+## To be copied in the UI
+# mod_template_manager_ui("template_manager_1")
+
+## To be copied in the server
+# mod_template_manager_server("template_manager_1")
+
+mod_template_manager_apptest <- function(id = "test") {
+    user_iniciado <- "dgco93@mininter.gob.pe"
+    ui <- bs4Dash::dashboardPage(
+        header = bs4Dash::dashboardHeader(title = "TEST"),
+        sidebar = bs4Dash::dashboardSidebar(
+            bs4Dash::sidebarMenu(
+                bs4Dash::menuItem(text = "Admin Templates",
+                                  tabName = "templates",
+                                  icon = icon("book"))
+            )
+        ),
+        body = bs4Dash::dashboardBody(
+            bs4Dash::tabItem(
+                tabName = "templates", 
+                mod_template_manager_ui(id),
+                mod_template_manager_output(id, user_iniciado)
+            )
+        )
+    )
+    
+    server <- function(input, output, session) {
+        mod_template_manager_server(id, user_iniciado)
+    }
+    
+    shinyApp(ui, server)
+}

--- a/R/mod_templates.R
+++ b/R/mod_templates.R
@@ -7,26 +7,26 @@
 #' @noRd
 #'
 #' @importFrom shiny NS tagList
-mod_templates_ui <- function(id){
-  ns <- NS(id)
-  tagList(
-    bs4Dash::box(
-      title = "Plantillas disponibles",
-      width = 12,
-      height = "600px",
-      sidebar = bs4Dash::boxSidebar(
-        id = ns("sidebar"),
-        width = 25,
-        # btn_refresh(ns("refresh")),
-        btn_add(ns("add_template")),
-        btn_trash(ns("rm_template")),
-        btn_expand(ns("expand"))
-      ),
-      div(),
-      DT::DTOutput(ns("tabla")),
-      div()
+mod_templates_ui <- function(id, user_iniciado) {
+    ns <- NS(id)
+    tagList(
+        fluidRow(
+            mod_template_manager_ui(ns("template_manager")),
+            btn_eliminar(ns("rm_template")),
+            btn_expand(ns("expand"))
+        ),
+        tags$hr(),
+        
+        mod_template_manager_output(ns("template_manager"), user_iniciado),
+        
+        bs4Dash::box(
+            title = "Plantillas disponibles",
+            width = 12,
+            height = "600px",
+            
+            DT::DTOutput(ns("tabla"))
+        )
     )
-  )
 }
 
 #' admin_templates Server Functions
@@ -35,12 +35,12 @@ mod_templates_ui <- function(id){
 mod_templates_server <- function(id, user_iniciado){
   moduleServer(id, function(input, output, session){
     ns <- session$ns
+    
+    btn_template_added <- mod_template_manager_server("template_manager", user_iniciado)
 
     group_id <- gruser_get_groups(user_iniciado)
     all_owners <- union(user_iniciado, group_id)
 
-    step_count <- reactiveVal(1L)
-    step_list_numbers <- reactive(seq_len(step_count()))
     user_templates <- reactiveVal(template_get_from_user(all_owners) |> template_get_data())
 
     selected_template <- reactive({
@@ -52,74 +52,6 @@ mod_templates_server <- function(id, user_iniciado){
     selected_template_id <- reactive(selected_template()$template_id)
 
     expanded_template <- reactive(step_get_from_template(selected_template_id()))
-
-    template_id <- reactive({
-      if (input$template_id == "") {
-          ids::proquint(n_words = 3, use_openssl = TRUE)
-      } else {
-        input$template_id
-      }
-    })
-
-    new_template_data <- reactive({
-      data.frame(
-        template_id = template_id(),
-        template_description = input$temp_description,
-        user_id = input$template_owner
-      )
-    })
-
-    new_template_steps_data <- reactive({
-      step_list_numbers() |>
-        lapply(function(x) {
-          data.frame(
-            user_id = input$template_owner,
-            template_id = template_id(),
-            step_id = sprintf("step_%02i", x),
-            step_description = input[[sprintf("step_%02i", x)]]
-          )
-        }) |>
-        (\(x) do.call(what = rbind, args = x))() # ugly but owrks in R 4.1
-        # do.call(what = rbind, args = _) # needs R 4.2
-    })
-
-    observeEvent(input$add_template, {
-
-        showModal(modalDialog(
-          title = "Añadir tareas a plantilla",
-          textInput(inputId = ns("temp_description"),
-                    label = "Nombre de plantilla",
-                    placeholder = "Ingresar nombre de plantilla"),
-          selectInput(
-            inputId = ns("template_owner"),
-            label = "Seleccione dueño de plantilla",
-            # choices = letters[1:5]
-            choices = setNames(all_owners, all_owners |> purrr::map_chr(user_get_names))
-          ),
-          checkboxInput(ns("plantilla_mapro"), label = "¿Es proceso MAPRO?"),
-          conditionalPanel(
-              condition = "input.plantilla_mapro",
-              ns = ns,
-              textInput(inputId = ns("template_id"),
-                        label = "ID de proceso",
-                        placeholder = "Solo llenar en procesos MAPRO")
-          ),
-          # h2("Plantilla nueva:"),
-          h5("Ingresar tareas"),
-          fluidRow(
-            col_10(
-              uiOutput(ns("step_list")),
-            ),
-            col_1(btn_add(ns("add_step"), size = "sm")),
-            col_1(btn_minus(ns("rm_step"), size = "sm"))
-          ),
-          footer = tagList(
-            modalButton("Cancelar"),
-            btn_agregar(ns("save_template_steps"))
-          )
-        ))
-
-    })
 
     observe({
         if (!isTruthy(selected_template_id())) {
@@ -137,39 +69,6 @@ mod_templates_server <- function(id, user_iniciado){
 
     }) |> bindEvent(input$expand)
 
-    observeEvent(input$add_step, step_count(step_count() + 1L))
-
-    observeEvent(input$rm_step, if (step_count() > 1L) step_count(step_count() - 1L))
-
-    observeEvent(input$save_template_steps, {
-
-      step_insert(new_template_steps_data())
-      template_insert(new_template_data())
-
-      removeModal()
-
-      updateTextInput(session = session,
-                      inputId = "temp_description",
-                      value = "")
-
-      updateTextInput(session = session,
-                      inputId = "template_id",
-                      value = "")
-
-      # Resetear todos los inputs de step
-      step_list_numbers() |>
-        lapply(function(x) {
-          updateTextInput(session = session,
-                          inputId = sprintf("step_%02i", x),
-                          value = "")
-        })
-
-      alert_success(session, "Plantilla añadida")
-
-      user_templates(template_get_from_user(all_owners) |> template_get_data())
-
-
-    })
 
     observeEvent(input$rm_template, {
       template_remove(selected_template_id())
@@ -179,18 +78,12 @@ mod_templates_server <- function(id, user_iniciado){
 
       user_templates(template_get_from_user(all_owners) |> template_get_data())
     })
+    
+    observe({
+        user_templates(template_get_from_user(all_owners) |> template_get_data())
+    }) |> bindEvent(btn_template_added())
 
-    output$step_list <- renderUI({
-      step_list_numbers() |>
-        lapply(function(x) {
-          textInput(
-            inputId = ns(sprintf("step_%02i", x)),
-            label = NULL,
-            placeholder = sprintf("Ingresar tarea %02i", x),
-            value = isolate(input[[sprintf("step_%02i", x)]])
-          )
-        })
-    })
+    
 
     output$tabla <- DT::renderDT(
       expr = user_templates(),
@@ -211,6 +104,7 @@ mod_templates_server <- function(id, user_iniciado){
 }
 
 mod_templates_testapp <- function(id = "test") {
+    user_iniciado <- "dgco93@mininter.gob.pe"
   ui <- bs4Dash::dashboardPage(
     header = bs4Dash::dashboardHeader(title = "TEST"),
     sidebar = bs4Dash::dashboardSidebar(
@@ -221,12 +115,11 @@ mod_templates_testapp <- function(id = "test") {
       )
     ),
     body = bs4Dash::dashboardBody(
-      bs4Dash::tabItem(tabName = "templates", mod_templates_ui(id))
+      bs4Dash::tabItem(tabName = "templates", mod_templates_ui(id, user_iniciado))
     )
   )
 
   server <- function(input, output, session) {
-    user_iniciado <- "dgco93@mininter.gob.pe"
     mod_templates_server(id, user_iniciado)
   }
 

--- a/R/mod_user_manager.R
+++ b/R/mod_user_manager.R
@@ -34,7 +34,7 @@ mod_user_manager_output <- function(id, user_iniciado) {
             ),
             btn_cancelar(ns("cancelar")),
             btn_guardar(ns("save"))
-        )
+        ) |> tagAppendAttributes(.cssSelector = glue::glue("#{ns('box_manager')}"), style = "display: none;")
     )
 }
 
@@ -45,7 +45,7 @@ mod_user_manager_server <- function(id, user_iniciado) {
     moduleServer(id, function(input, output, session) {
         ns <- session$ns
 
-        bs4Dash::updateBox("box_manager", "remove")
+        # bs4Dash::updateBox("box_manager", "remove")
 
         out <- reactiveValues(
             save_sucess = 0

--- a/R/mod_user_manager.R
+++ b/R/mod_user_manager.R
@@ -1,0 +1,138 @@
+#' user_manager UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd
+#'
+#' @importFrom shiny NS tagList
+mod_user_manager_ui <- function(id, user_iniciado) {
+    ns <- NS(id)
+    tagList(
+        btn_agregar(ns("add"), icon = icon("plus"))
+    )
+}
+
+mod_user_manager_output <- function(id, user_iniciado) {
+    ns <- NS(id)
+    tagList(
+        bs4Dash::box(
+            title = "Gestión de usuario",
+            id = ns("box_manager"),
+            width = 12,
+
+            fluidRow(
+                col_4(textInput(ns("user_id"), "ID")),
+                col_4(textInput(ns("name"), "Nombres")),
+                col_4(textInput(ns("last_name"), "Apellidos"))
+            ),
+            fluidRow(
+                col_4(selectInput(ns("privileges"), "Privilegios", choices = c("user1", "user2", "admin"))),
+                col_4(selectInput(ns("responds_to"), "Responde a:", choices = user_get_from_privileges("user2"))),
+                col_4(dateInput(ns("date_added"), "Fecha", language = "es", value = lubridate::today("America/Lima")))
+            ),
+            btn_cancelar(ns("cancelar")),
+            btn_guardar(ns("save"))
+        )
+    )
+}
+
+#' user_manager Server Functions
+#'
+#' @noRd
+mod_user_manager_server <- function(id, user_iniciado) {
+    moduleServer(id, function(input, output, session) {
+        ns <- session$ns
+
+        bs4Dash::updateBox("box_manager", "remove")
+
+        out <- reactiveValues(
+            save_sucess = 0
+        )
+
+        reset_ui <- function() {
+            updateTextInput(session, "user_id", value = "")
+            updateTextInput(session, "name", value = "")
+            updateTextInput(session, "last_name", value = "")
+            updateSelectInput(session, "privileges", selected = "user1")
+            updateSelectInput(session, "responds_to", choices = user_get_from_privileges("user2"))
+        }
+
+        new_user_data <- reactive({
+            data.frame(
+                user_id = input$user_id,
+                name = input$name,
+                last_name = input$last_name,
+                privileges = input$privileges,
+                responds_to = input$responds_to,
+                date_added = as.character(input$date_added)
+            )
+        })
+
+        observe({
+            if (isFalsy(input$user_id, input$name, input$last_name)) {
+                alert_error(session, "Debe especificar datos completos de usuario")
+            } else {
+                user_insert(new_user_data())
+
+                reset_ui()
+
+                out$save_success <- out$save_success + 1
+
+                bs4Dash::updateBox(id = "box_manager", action = "remove")
+                alert_info(session = session, sprintf("Se añadió al usuario %s", input$user_id))
+            }
+        }) |> bindEvent(input$save)
+
+        observe({
+            bs4Dash::updateBox(id = "box_manager", action = "restore")
+        }) |> bindEvent(input$add)
+
+        observe({
+            reset_ui()
+            bs4Dash::updateBox(id = "box_manager", action = "remove")
+
+        }) |> bindEvent(input$cancelar)
+
+        # return value
+        reactive(out$save_success)
+
+    })
+}
+
+## To be copied in the UI
+# mod_user_manager_ui("user_manager_1")
+
+## To be copied in the server
+# mod_user_manager_server("user_manager_1")
+
+
+mod_user_manager_apptest <- function(user_iniciado = "dgco93@mininter.gob.pe") {
+    ui <- tagList(
+        bs4Dash::dashboardPage(
+            header = bs4Dash::dashboardHeader(title = "TEST"),
+            sidebar = bs4Dash::dashboardSidebar(
+                bs4Dash::sidebarMenu(
+                    bs4Dash::menuItem(text = "Test",
+                                      tabName = "tasks",
+                                      icon = icon("user"))
+                )
+            ),
+            body = bs4Dash::dashboardBody(
+                bs4Dash::tabItem(
+                    tabName = "tasks",
+                    mod_user_manager_ui("test", user_iniciado),
+                    tags$hr(),
+                    mod_user_manager_output("test", user_iniciado)
+                )
+            )
+        )
+    )
+
+    server <- function(input, output, session) {
+        mod_user_manager_server("test", user_iniciado)
+    }
+
+    shinyApp(ui, server)
+}

--- a/R/mod_user_manager.R
+++ b/R/mod_user_manager.R
@@ -7,14 +7,14 @@
 #' @noRd
 #'
 #' @importFrom shiny NS tagList
-mod_user_manager_ui <- function(id, user_iniciado) {
+mod_user_manager_ui <- function(id) {
     ns <- NS(id)
     tagList(
         btn_agregar(ns("add"), icon = icon("plus"))
     )
 }
 
-mod_user_manager_output <- function(id, user_iniciado) {
+mod_user_manager_output <- function(id) {
     ns <- NS(id)
     tagList(
         bs4Dash::box(
@@ -34,14 +34,16 @@ mod_user_manager_output <- function(id, user_iniciado) {
             ),
             btn_cancelar(ns("cancelar")),
             btn_guardar(ns("save"))
-        ) |> tagAppendAttributes(.cssSelector = glue::glue("#{ns('box_manager')}"), style = "display: none;")
+        ) |>
+            boxHide()
+            # tagAppendAttributes(.cssSelector = glue::glue("#{ns('box_manager')}"), style = "display: none;")
     )
 }
 
 #' user_manager Server Functions
 #'
 #' @noRd
-mod_user_manager_server <- function(id, user_iniciado) {
+mod_user_manager_server <- function(id) {
     moduleServer(id, function(input, output, session) {
         ns <- session$ns
 
@@ -108,7 +110,7 @@ mod_user_manager_server <- function(id, user_iniciado) {
 # mod_user_manager_server("user_manager_1")
 
 
-mod_user_manager_apptest <- function(user_iniciado = "dgco93@mininter.gob.pe") {
+mod_user_manager_apptest <- function() {
     ui <- tagList(
         bs4Dash::dashboardPage(
             header = bs4Dash::dashboardHeader(title = "TEST"),
@@ -122,16 +124,16 @@ mod_user_manager_apptest <- function(user_iniciado = "dgco93@mininter.gob.pe") {
             body = bs4Dash::dashboardBody(
                 bs4Dash::tabItem(
                     tabName = "tasks",
-                    mod_user_manager_ui("test", user_iniciado),
+                    mod_user_manager_ui("test"),
                     tags$hr(),
-                    mod_user_manager_output("test", user_iniciado)
+                    mod_user_manager_output("test")
                 )
             )
         )
     )
 
     server <- function(input, output, session) {
-        mod_user_manager_server("test", user_iniciado)
+        mod_user_manager_server("test")
     }
 
     shinyApp(ui, server)

--- a/R/mod_user_manager.R
+++ b/R/mod_user_manager.R
@@ -34,9 +34,7 @@ mod_user_manager_output <- function(id) {
             ),
             btn_cancelar(ns("cancelar")),
             btn_guardar(ns("save"))
-        ) |>
-            boxHide()
-            # tagAppendAttributes(.cssSelector = glue::glue("#{ns('box_manager')}"), style = "display: none;")
+        ) |> boxHide()
     )
 }
 
@@ -82,18 +80,18 @@ mod_user_manager_server <- function(id) {
 
                 out$save_success <- out$save_success + 1
 
-                bs4Dash::updateBox(id = "box_manager", action = "remove")
+                bs4Dash::updateBox(id = "box_manager", action = "remove", session = session)
                 alert_info(session = session, sprintf("Se añadió al usuario %s", input$user_id))
             }
         }) |> bindEvent(input$save)
 
         observe({
-            bs4Dash::updateBox(id = "box_manager", action = "restore")
+            bs4Dash::updateBox(id = "box_manager", action = "restore", session = session)
         }) |> bindEvent(input$add)
 
         observe({
             reset_ui()
-            bs4Dash::updateBox(id = "box_manager", action = "remove")
+            bs4Dash::updateBox(id = "box_manager", action = "remove", session = session)
 
         }) |> bindEvent(input$cancelar)
 

--- a/R/mod_users.R
+++ b/R/mod_users.R
@@ -10,15 +10,16 @@
 mod_users_ui <- function(id) {
   ns <- NS(id)
   tagList(
+      mod_user_manager_ui(ns("user_manager")),
+      btn_trash(ns("delete_user")),
     bs4Dash::box(
-      title = "Gestión de usuarios",
+      title = "Usuarios registrados",
       width = 12,
-      sidebar = bs4Dash::boxSidebar(
-        id = ns("sidebar"),
-        width = 25,
-        btn_add(ns("add")),
-        btn_trash(ns("delete_user"))
-      ),
+      # sidebar = bs4Dash::boxSidebar(
+      #   id = ns("sidebar"),
+      #   width = 25,
+      #   btn_add(ns("add"))
+      # ),
       DT::DTOutput(ns("tabla"))
     )
   )
@@ -36,56 +37,56 @@ mod_users_server <- function(id){
       data_users = user_get_all()
     )
 
-    new_user_data <- reactive({
-      data.frame(
-        user_id = input$user_id,
-        name = input$name,
-        last_name = input$last_name,
-        privileges = input$privileges,
-        responds_to = input$responds_to,
-        date_added = as.character(input$date_added)
-      )
-    })
+    # new_user_data <- reactive({
+    #   data.frame(
+    #     user_id = input$user_id,
+    #     name = input$name,
+    #     last_name = input$last_name,
+    #     privileges = input$privileges,
+    #     responds_to = input$responds_to,
+    #     date_added = as.character(input$date_added)
+    #   )
+    # })
 
     user_for_deleting <- reactive({
       vals$data_users$user_id[input$tabla_rows_selected]
     })
 
-    observeEvent(input$add, {
-      showModal(modalDialog(
-        title = "Nuevo usuario",
+    # observeEvent(input$add, {
+    #   showModal(modalDialog(
+    #     title = "Nuevo usuario",
+    #
+    #     textInput(ns("user_id"), "ID"),
+    #     textInput(ns("name"), "Nombres"),
+    #     textInput(ns("last_name"), "Apellidos"),
+    #     selectInput(ns("privileges"), "Privilegios", choices = c("user1", "user2", "admin")),
+    #     selectInput(ns("responds_to"), "Responde a:", choices = user_get_from_privileges("user2")),
+    #     dateInput(ns("date_added"), "Fecha", language = "es", value = lubridate::today("America/Lima")),
+    #
+    #     footer = tagList(
+    #       modalButton("Cancelar"),
+    #       btn_agregar(ns("insert_user"))
+    #     )
+    #   ))
+    # })
 
-        textInput(ns("user_id"), "ID"),
-        textInput(ns("name"), "Nombres"),
-        textInput(ns("last_name"), "Apellidos"),
-        selectInput(ns("privileges"), "Privilegios", choices = c("user1", "user2", "admin")),
-        selectInput(ns("responds_to"), "Responde a:", choices = user_get_from_privileges("user2")),
-        dateInput(ns("date_added"), "Fecha", language = "es", value = lubridate::today("America/Lima")),
-
-        footer = tagList(
-          modalButton("Cancelar"),
-          btn_agregar(ns("insert_user"))
-        )
-      ))
-    })
-
-    observeEvent(input$insert_user, {
-
-      user_insert(new_user_data())
-
-      updateTextInput(session, "user_id", value = "")
-      updateTextInput(session, "name", value = "")
-      updateTextInput(session, "last_name", value = "")
-      updateSelectInput(session, "privileges", selected = "user1")
-      updateSelectInput(session, "responds_to", choices = user_get_from_privileges("user2"))
-
-      vals$data_users <- user_get_all()
-
-      removeModal()
-
-      alert_info(session = session, sprintf("Se añadió al usuario %s", input$user_id))
-
-    })
+    # observeEvent(input$insert_user, {
+    #
+    #   user_insert(new_user_data())
+    #
+    #   updateTextInput(session, "user_id", value = "")
+    #   updateTextInput(session, "name", value = "")
+    #   updateTextInput(session, "last_name", value = "")
+    #   updateSelectInput(session, "privileges", selected = "user1")
+    #   updateSelectInput(session, "responds_to", choices = user_get_from_privileges("user2"))
+    #
+    #   vals$data_users <- user_get_all()
+    #
+    #   removeModal()
+    #
+    #   alert_info(session = session, sprintf("Se añadió al usuario %s", input$user_id))
+    #
+    # })
 
     observeEvent(input$delete_user,{
         if (isTruthy(user_for_deleting())) {

--- a/R/mod_users.R
+++ b/R/mod_users.R
@@ -10,10 +10,10 @@
 mod_users_ui <- function(id) {
   ns <- NS(id)
   tagList(
-      mod_user_manager_ui(ns("user_manager"), user_iniciado),
+      mod_user_manager_ui(ns("user_manager")),
       btn_eliminar(ns("delete_user"), icon = icon("trash")),
       tags$hr(),
-      mod_user_manager_output(ns("user_manager"), user_iniciado),
+      mod_user_manager_output(ns("user_manager")),
     bs4Dash::box(
       title = "Usuarios registrados",
       width = 12,

--- a/R/mod_users.R
+++ b/R/mod_users.R
@@ -54,8 +54,6 @@ mod_users_server <- function(id){
         vals$data_users <- user_get_all()
     }) |> bindEvent(btn_usuario_agregado())
 
-    observe(print(user_for_deleting())) |> bindEvent(input$tabla_rows_selected)
-
     output$tabla <- DT::renderDT(
       expr = vals$data_users,
       options = options_DT(),

--- a/R/mod_users.R
+++ b/R/mod_users.R
@@ -10,16 +10,13 @@
 mod_users_ui <- function(id) {
   ns <- NS(id)
   tagList(
-      mod_user_manager_ui(ns("user_manager")),
-      btn_trash(ns("delete_user")),
+      mod_user_manager_ui(ns("user_manager"), user_iniciado),
+      btn_eliminar(ns("delete_user"), icon = icon("trash")),
+      tags$hr(),
+      mod_user_manager_output(ns("user_manager"), user_iniciado),
     bs4Dash::box(
       title = "Usuarios registrados",
       width = 12,
-      # sidebar = bs4Dash::boxSidebar(
-      #   id = ns("sidebar"),
-      #   width = 25,
-      #   btn_add(ns("add"))
-      # ),
       DT::DTOutput(ns("tabla"))
     )
   )
@@ -33,63 +30,18 @@ mod_users_server <- function(id){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
 
+    btn_usuario_agregado <- mod_user_manager_server("user_manager")
+
     vals <- reactiveValues(
       data_users = user_get_all()
     )
-
-    # new_user_data <- reactive({
-    #   data.frame(
-    #     user_id = input$user_id,
-    #     name = input$name,
-    #     last_name = input$last_name,
-    #     privileges = input$privileges,
-    #     responds_to = input$responds_to,
-    #     date_added = as.character(input$date_added)
-    #   )
-    # })
 
     user_for_deleting <- reactive({
       vals$data_users$user_id[input$tabla_rows_selected]
     })
 
-    # observeEvent(input$add, {
-    #   showModal(modalDialog(
-    #     title = "Nuevo usuario",
-    #
-    #     textInput(ns("user_id"), "ID"),
-    #     textInput(ns("name"), "Nombres"),
-    #     textInput(ns("last_name"), "Apellidos"),
-    #     selectInput(ns("privileges"), "Privilegios", choices = c("user1", "user2", "admin")),
-    #     selectInput(ns("responds_to"), "Responde a:", choices = user_get_from_privileges("user2")),
-    #     dateInput(ns("date_added"), "Fecha", language = "es", value = lubridate::today("America/Lima")),
-    #
-    #     footer = tagList(
-    #       modalButton("Cancelar"),
-    #       btn_agregar(ns("insert_user"))
-    #     )
-    #   ))
-    # })
-
-    # observeEvent(input$insert_user, {
-    #
-    #   user_insert(new_user_data())
-    #
-    #   updateTextInput(session, "user_id", value = "")
-    #   updateTextInput(session, "name", value = "")
-    #   updateTextInput(session, "last_name", value = "")
-    #   updateSelectInput(session, "privileges", selected = "user1")
-    #   updateSelectInput(session, "responds_to", choices = user_get_from_privileges("user2"))
-    #
-    #   vals$data_users <- user_get_all()
-    #
-    #   removeModal()
-    #
-    #   alert_info(session = session, sprintf("Se añadió al usuario %s", input$user_id))
-    #
-    # })
-
     observeEvent(input$delete_user,{
-        if (isTruthy(user_for_deleting())) {
+        if (!isTruthy(user_for_deleting())) {
             alert_error(session, "Debe seleccionar usuario a eliminar")
         } else {
             user_remove(user_for_deleting())
@@ -97,6 +49,12 @@ mod_users_server <- function(id){
             vals$data_users <- user_get_all()
         }
     })
+
+    observe({
+        vals$data_users <- user_get_all()
+    }) |> bindEvent(btn_usuario_agregado())
+
+    observe(print(user_for_deleting())) |> bindEvent(input$tabla_rows_selected)
 
     output$tabla <- DT::renderDT(
       expr = vals$data_users,


### PR DESCRIPTION
Las nuevas tareas, nuevas plantillas y nuevos usuarios ya no se duplican. Fix #36 fix #33 fix #51 