### PR TITLE
Cambios en el layout de tarjeta y el añadido de tareas

### DIFF
--- a/R/mod_board.R
+++ b/R/mod_board.R
@@ -104,7 +104,8 @@ mod_board_server <- function(id, AppData, config) {
         task_gets_added <- mod_task_add_server(
             id = "task_add_1", 
             AppData = AppData, 
-            trigger = reactive(input$task_add)
+            trigger = reactive(input$task_add),
+            config = config
         )
         
         # Reactives ----

--- a/R/mod_task_add.R
+++ b/R/mod_task_add.R
@@ -17,7 +17,7 @@ mod_task_add_ui <- function(id){
 #' task_add Server Functions
 #'
 #' @noRd 
-mod_task_add_server <- function(id, AppData, trigger){
+mod_task_add_server <- function(id, AppData, trigger, config){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     

--- a/R/task_box.R
+++ b/R/task_box.R
@@ -2,7 +2,7 @@ task_box <- function(task, ns = NULL, is_group_admin = FALSE) {
     id <- ns_safe(task$task_id, ns)
     
     dropdown <- task_dropdown(id, task$status_current, is_group_admin)
-        
+    
     bs4Dash::box(
         id = id,
         title = task$task_title,
@@ -11,21 +11,22 @@ task_box <- function(task, ns = NULL, is_group_admin = FALSE) {
         headerBorder = FALSE,
         background = task$user_color,
         label = bs4Dash::boxLabel(
-            text = glue::glue("{task$output_current}/{task$output_goal}"), 
-            status = "primary",
+            text = format(task$time_due, "%d %b"), 
+            status = task_status_from_time_due(task$time_due),
             tooltip = task$output_unit
         ),
         dropdownMenu = dropdown,
         tags$p(task$task_description),
+        task_assignee_div(task),
+        # tags$div(
+        #     tags$span(fontawesome::fa("far fa-user"), glue::glue("{task$assignee_name} {task$assignee_last_name}"))
+        # ),
+        # tags$div(
+        #     tags$span(fontawesome::fa("far fa-thumbs-up"), glue::glue("{task$assigned_by_name} {task$assigned_by_last_name}"))
+        # ),
         tags$div(
-            tags$span(fontawesome::fa("far fa-user"), glue::glue("{task$assignee_name} {task$assignee_last_name}"))
-        ),
-        tags$div(
-            tags$span(fontawesome::fa("far fa-thumbs-up"), glue::glue("{task$assigned_by_name} {task$assigned_by_last_name}"))
-        ),
-        tags$div(
-            tags$span(fontawesome::fa("far fa-calendar"), format(task$time_due, "%d/%m/%Y")),
-            tags$span(fontawesome::fa("far fa-clock"), format(task$time_due, "%H:%M:%S"))
+            tags$span(fontawesome::fa("far fa-clock"), format(task$time_due, "%H:%M:%S")),
+            tags$span(fontawesome::fa("fas fa-bullseye"), glue::glue("{task$output_current}/{task$output_goal} {task$output_unit}"), style = "float: right;")
         )
     )
 }
@@ -82,4 +83,29 @@ task_dropdown <- function(id, status, is_group_admin) {
         icon = fontawesome::fa("fas fa-ellipsis"), dd_items
         
     )
+}
+
+task_status_from_time_due <- function(time_due) {
+    if (as.Date(time_due) > lubridate::today("America/Lima")) {
+        "success"
+    } else if (as.Date(time_due) == lubridate::today("America/Lima")) {
+        "warning"
+    } else  "danger"
+}
+
+task_assignee_div <- function(task) {
+    if (task$assignee == task$assigned_by) {
+        tags$div(
+            tags$span(fontawesome::fa("far fa-user"), fontawesome::fa("far fa-thumbs-up"), glue::glue("{task$assignee_name} {task$assignee_last_name}"))
+        )
+    } else {
+        tagList(
+            tags$div(
+                tags$span(fontawesome::fa("far fa-user"), glue::glue("{task$assignee_name} {task$assignee_last_name}"))
+            ),
+            tags$div(
+                tags$span(fontawesome::fa("far fa-thumbs-up"), glue::glue("{task$assigned_by_name} {task$assigned_by_last_name}"))
+            )
+        )
+    }
 }

--- a/R/task_box.R
+++ b/R/task_box.R
@@ -18,12 +18,6 @@ task_box <- function(task, ns = NULL, is_group_admin = FALSE) {
         dropdownMenu = dropdown,
         tags$p(task$task_description),
         task_assignee_div(task),
-        # tags$div(
-        #     tags$span(fontawesome::fa("far fa-user"), glue::glue("{task$assignee_name} {task$assignee_last_name}"))
-        # ),
-        # tags$div(
-        #     tags$span(fontawesome::fa("far fa-thumbs-up"), glue::glue("{task$assigned_by_name} {task$assigned_by_last_name}"))
-        # ),
         tags$div(
             tags$span(fontawesome::fa("far fa-clock"), format(task$time_due, "%H:%M:%S")),
             tags$span(fontawesome::fa("fas fa-bullseye"), glue::glue("{task$output_current}/{task$output_goal} {task$output_unit}"), style = "float: right;")


### PR DESCRIPTION
## Card layout

La tarjeta de tarea tiene nueva distribución. Antes:

![image](https://user-images.githubusercontent.com/19418298/212998759-feb7a699-5888-4319-8ba3-2db27ec8a5fe.png)

Ahora:

![image](https://user-images.githubusercontent.com/19418298/212998535-3c43f9ab-1ef3-4904-8308-b546a5eee959.png)

- La fecha límite es mostrada como etiqueta
- El color de la etiqueta es relativo a la fecha límite (verde antes, amarillo durante, y rojo después)
- El avance y unidad de medida de meta se muestran en la parte inferior derecha
- Si el responsable de tarea y el asignador son la misma persona, el nombre aparece solo una vez

## Adición de tarea

- Ya no es necesario escoger organización y grupo para cada tarea nueva. La elección hecha en Configuración se aplica a las nuevas tareas. Esto significa que el tablero solo mostrará tareas de un solo grupo a la vez.