### PR TITLE
[BOARD] Botón 'Archivar' es interactuable en tareas 'En revisión'

### DIFF
--- a/R/task_box.R
+++ b/R/task_box.R
@@ -99,9 +99,13 @@ task_dropdown <- function(ns, value, status, is_group_admin) {
             tagList(
                 item_revisar, item_historia
             )
-        } else {
+        } else if (status == "Terminado" && is_group_admin) {
             tagList(
                 item_historia, item_archivar
+            )
+        } else {
+            tagList(
+                item_historia
             )
         }
 


### PR DESCRIPTION
Arregla un bug que permitía que usuarios no responsables de equipo puedan archivar tareas terminadas y en revisión. Fixes #137