### PR TITLE
[BOARD] Vista de historial solo muestra un mensaje de error

### DIFF
--- a/R/mod_board.R
+++ b/R/mod_board.R
@@ -458,13 +458,14 @@ mod_board_server <- function(id, app_data, controlbar) {
         output$table_history <- reactable::renderReactable({
             app_data$task_get_history(rv$task_to_history$task_id) |> 
                 purrr::pmap(list) |> 
-                purrr::map_dfr(~data.frame(
+                purrr::map(~tibble::tibble(
                     "Fecha" = format(.x$time_reported, "%d/%m/%Y %H:%M:%S"),
                     "Por" = .x$user_names,
                     "Estado" = .x$status,
                     "Progreso" = .x$output_progress,
                     "Detalle" = .x$details
                 )) |> 
+                purrr::reduce(rbind) |>
                 reactable::reactable()
         })
         


### PR DESCRIPTION
Se elimina la dependencia en `{dplyr}` para la creación de la tabla. Fixes #133