### PR TITLE
[BOARD] Hacer click en botón de editar unidad de medida genera que la app se cierre

### DIFF
--- a/R/mod_group_units.R
+++ b/R/mod_group_units.R
@@ -162,7 +162,9 @@ mod_group_units_server <- function(id, app_data, processes) {
         ## Edition ----
         observe({
             
-            unit_selected <- group_units()[[input$unitToEdit]]
+            unit_selected <- group_units() |>
+                purrr::keep(~.x$unit_id == input$unitToEdit) |>
+                purrr::pluck(1)
             
             showModal(modalDialog(
                 title = "Editar unidad de medida",


### PR DESCRIPTION
Se corrige bug que no permitía editar unidades de medida. Fixes #136