### PR TITLE
[BOARD] Reportes no se cargan al elegir grupo

### DIFF
--- a/R/mod_board.R
+++ b/R/mod_board.R
@@ -130,6 +130,7 @@ mod_board_server <- function(id, app_data, controlbar) {
         }) |>
             bindEvent(
                 report_gets_added(),
+                controlbar$group_selected(),
                 rv$reports_modified
             )
         


### PR DESCRIPTION
Corrige un bug evitaba mostrar los reportes al cambiar de grupo. Fixes #135